### PR TITLE
Align owner plugins with owner_key settings field

### DIFF
--- a/src/stable/plugins/ds_collar_plugin_owner.lsl
+++ b/src/stable/plugins/ds_collar_plugin_owner.lsl
@@ -43,6 +43,8 @@ string CONS_MSG_ACL_RESULT         = "acl_result";
 /* Settings protocol (JSON) */
 string CONS_SETTINGS_SYNC          = "settings_sync";   // inbound/outbound
 string CONS_SETTINGS_NS_OWNER      = "owner";           // namespace/key for this module
+string KEY_OWNER_KEY               = "owner_key";
+string KEY_OWNER_LEGACY            = "owner";
 
 /* ---------- Identity ---------- */
 string  PLUGIN_CONTEXT   = "core_owner";
@@ -175,9 +177,13 @@ integer request_acl(key av) {
 /* Push our mirror to kernel */
 integer push_settings() {
     string j = llList2Json(JSON_OBJECT, []);
+    string owner_str = (string)collar_owner;
+
     j = llJsonSetValue(j, ["type"],   CONS_SETTINGS_SYNC);
     j = llJsonSetValue(j, ["ns"],     CONS_SETTINGS_NS_OWNER);
-    j = llJsonSetValue(j, ["owner"],  (string)collar_owner);
+    j = llJsonSetValue(j, [KEY_OWNER_KEY], owner_str);
+    /* Legacy mirror for older cores/plugins */
+    j = llJsonSetValue(j, [KEY_OWNER_LEGACY], owner_str);
 
     string hon = collar_owner_honorific;
     if (hon == "") hon = " ";
@@ -204,7 +210,8 @@ integer ingest_settings(string j) {
 
     key prev_owner = collar_owner;
 
-    if (json_has(j, ["owner"]))       collar_owner           = (key)llJsonGetValue(j, ["owner"]);
+    if (json_has(j, [KEY_OWNER_KEY]))  collar_owner           = (key)llJsonGetValue(j, [KEY_OWNER_KEY]);
+    else if (json_has(j, [KEY_OWNER_LEGACY])) collar_owner     = (key)llJsonGetValue(j, [KEY_OWNER_LEGACY]);
     if (json_has(j, ["owner_hon"]))   collar_owner_honorific = llJsonGetValue(j, ["owner_hon"]);
     if (json_has(j, ["trustees"])) {
         list arr = llJson2List(llJsonGetValue(j, ["trustees"]));

--- a/src/stable/plugins/ds_collar_plugin_trustees.lsl
+++ b/src/stable/plugins/ds_collar_plugin_trustees.lsl
@@ -39,6 +39,8 @@ string CONS_MSG_ACL_RESULT         = "acl_result";
 /* Settings protocol (JSON) */
 string CONS_SETTINGS_SYNC          = "settings_sync";  // in/out
 string CONS_SETTINGS_NS_OWNER      = "owner";          // same NS as Owner plugin
+string KEY_OWNER_KEY               = "owner_key";
+string KEY_OWNER_LEGACY            = "owner";
 
 /* ---------- Identity ---------- */
 string  PLUGIN_CONTEXT   = "core_trustees";
@@ -141,7 +143,8 @@ integer request_acl(key av) {
 integer ingest_settings(string j) {
     if (json_has(j, ["ns"]) && llJsonGetValue(j, ["ns"]) != CONS_SETTINGS_NS_OWNER) return 0;
 
-    if (json_has(j, ["owner"]))        collar_owner = (key)llJsonGetValue(j, ["owner"]);
+    if (json_has(j, [KEY_OWNER_KEY]))   collar_owner = (key)llJsonGetValue(j, [KEY_OWNER_KEY]);
+    else if (json_has(j, [KEY_OWNER_LEGACY])) collar_owner = (key)llJsonGetValue(j, [KEY_OWNER_LEGACY]);
     if (json_has(j, ["trustees"]))     collar_trustees = llJson2List(llJsonGetValue(j, ["trustees"]));
     if (json_has(j, ["trustees_hon"])) collar_trustee_honorifics = llJson2List(llJsonGetValue(j, ["trustees_hon"]));
 


### PR DESCRIPTION
## Summary
- update the owner plugin to read the canonical `owner_key` field while still mirroring the legacy `owner` key
- ensure owner state pushes write both `owner_key` and `owner` so older components stay synchronized
- adjust the trustees plugin to consume the same `owner_key` field with a legacy fallback

## Testing
- not run (LSL scripts)


------
https://chatgpt.com/codex/tasks/task_e_68cff24aa8c4832b863458b7e3f5d6d9