### PR TITLE
Fix UI ACL filtering for trustees and owners

### DIFF
--- a/src/stable/modules/ds_collar_kmod_ui.lsl
+++ b/src/stable/modules/ds_collar_kmod_ui.lsl
@@ -159,45 +159,14 @@ list filterForViewer(){
                 /* Non-TPE paths */
                 if (!gIsWearer){
                     /* Touchers */
-                    if (pol_public_only){
+                    if (pol_public_only && gAcl <= 1){
                         if (minAcl == 1){
                             /* ok */
                         } else {
                             include = FALSE;
                         }
-                    } else if (pol_trustee_access){
-                        if (gAcl == 3){
-                            if (minAcl == 3){
-                                /* ok */
-                            } else {
-                                include = FALSE;
-                            }
-                        } else {
-                            /* if not trustee, fall through to normal ACL */
-                            if (minAcl <= gAcl){
-                                /* ok */
-                            } else {
-                                include = FALSE;
-                            }
-                        }
-                    } else if (pol_primary_owner){
-                        /* strict owner view: only min_acl==5 */
-                        if (gAcl == 5){
-                            if (minAcl == 5){
-                                /* ok */
-                            } else {
-                                include = FALSE;
-                            }
-                        } else {
-                            /* not owner: normal ACL */
-                            if (minAcl <= gAcl){
-                                /* ok */
-                            } else {
-                                include = FALSE;
-                            }
-                        }
                     } else {
-                        /* default toucher mapping: <= ACL */
+                        /* Trustee / owner levels retain full <= ACL visibility */
                         if (minAcl <= gAcl){
                             /* ok */
                         } else {


### PR DESCRIPTION
## Summary
- update the UI module filtering so trustees and primary owners keep full access when public mode is off or on

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d086dee650832ba83ef4865abd796b