### PR TITLE
Fix experimental UI lane compliance and request flow

### DIFF
--- a/src/experimental/ds_collar_kmod_ui_backend.lsl
+++ b/src/experimental/ds_collar_kmod_ui_backend.lsl
@@ -1,11 +1,11 @@
 /* =============================================================
  MODULE: ds_collar_kmod_ui_backend.lsl
  ROLE  : UI backend
-         - Receives ui_touch from FE → rebroadcasts ui_touched to plugins
+         - Receives ui_touch/ui_click from FE via API lanes
          - Receives ui_register_buttons → stores menus by context
          - Receives ui_draw → queries ACL, filters buttons, emits ui_render
          - Receives ui_show_message → renders simple message dialog
- LANES :  L_API (-1000), L_BROADCAST (-1001), L_UI_BE_IN (-1600)
+ LANES :  L_API (-1000), L_UI_BE_IN (-1600)
  DEPENDS: api (router), acl, ui_frontend
  ============================================================= */
 
@@ -14,26 +14,24 @@ integer logd(string s){ if (DEBUG) llOwnerSay("[UI-BE] " + s); return 0; }
 
 /* Lanes */
 integer L_API        = -1000;
-integer L_BROADCAST  = -1001;
 integer L_UI_BE_IN   = -1600;
 
 /* Types */
 string T_HELLO        = "hello";
 string T_UI_TOUCH     = "ui_touch";      // FE → BE
-string T_UI_TOUCHED   = "ui_touched";    // BE → any (broadcast for plugins)
 string T_UI_DRAW      = "ui_draw";       // plugin → BE
 string T_UI_RENDER    = "ui_render";     // BE → FE (via API)
 string T_UI_REGISTER  = "ui_register_buttons";
-string T_UI_BUTTON    = "ui_button";     // FE → any (plugins handle)
+string T_UI_CLICK     = "ui_click";      // FE → BE
 string T_UI_CLOSE     = "ui_close";
 string T_UI_MESSAGE   = "ui_show_message";
 
 string T_ACL_FILTER   = "acl_filter";
 string T_ACL_FRES     = "acl_filter_result";
 
-/* Pending ACL requests: stride=7
-   [req_id, avatar, session, context, title, body, buttons_json] */
-list Pending; integer PS = 7;
+/* Pending ACL requests: stride=8
+   [req_id, avatar, session, context, title, body, buttons_json, origin_req_id] */
+list Pending; integer PS = 8;
 
 /* Menus by context: stride=2 [context, buttons_json] */
 list Menus;   integer MS = 2;
@@ -44,12 +42,18 @@ string JA(){ return llList2Json(JSON_ARRAY, []); }
 string JSET(string j, list path, string v){ return llJsonSetValue(j, path, v); }
 string JGET(string j, list path){ return llJsonGetValue(j, path); }
 
+string DEFAULT_CONTEXT = "home";
+
+string be_make_session_for(key av){
+    return "be" + llGetSubString((string)av, 0, 5) + "-" + (string)llGetUnixTime();
+}
+
 /* Pending helpers */
 string new_req_id(){
     return "be-" + (string)llGetUnixTime() + "-" + llGetSubString((string)llGenerateKey(),0,7);
 }
-integer pend_add(string rid, key av, string sid, string ctx, string t, string b, string btns){
-    Pending += [rid, (string)av, sid, ctx, t, b, btns];
+integer pend_add(string rid, key av, string sid, string ctx, string t, string b, string btns, string origin_req_id){
+    Pending += [rid, (string)av, sid, ctx, t, b, btns, origin_req_id];
     return TRUE;
 }
 integer pend_idx(string rid){
@@ -159,7 +163,7 @@ string filter_buttons_by_level(string btns_json, integer level){
 }
 
 /* ---------- ACL query ---------- */
-integer request_level_for(key av, string sid, string ctx, string title, string body, string btns){
+integer request_level_for(key av, string sid, string ctx, string title, string body, string btns, string origin_req_id){
     string rid = new_req_id();
 
     string features = JA(); // empty: just want "level"
@@ -172,14 +176,14 @@ integer request_level_for(key av, string sid, string ctx, string title, string b
     j = JSET(j, ["avatar"],  (string)av);
     j = JSET(j, ["features"], features);
 
-    pend_add(rid, av, sid, ctx, title, body, btns);
+    pend_add(rid, av, sid, ctx, title, body, btns, origin_req_id);
     llMessageLinked(LINK_SET, L_API, j, NULL_KEY);
     if (DEBUG) logd("REQ acl_filter rid="+rid+" for "+(string)av);
     return TRUE;
 }
 
 /* ---------- Render to FE ---------- */
-integer render_to_frontend(key av, string sid, string ctx, string title, string body, string btns_filtered){
+integer render_to_frontend(key av, string sid, string ctx, string title, string body, string btns_filtered, string origin_req_id){
     string r = J();
     r = JSET(r, ["type"],    T_UI_RENDER);
     r = JSET(r, ["from"],    "ui_backend");
@@ -191,21 +195,44 @@ integer render_to_frontend(key av, string sid, string ctx, string title, string 
     r = JSET(r, ["title"],   title);
     r = JSET(r, ["body"],    body);
     r = llJsonSetValue(r, ["buttons"], btns_filtered);
+    if (origin_req_id != "") r = JSET(r, ["req_id"], origin_req_id);
 
     llMessageLinked(LINK_SET, L_API, r, NULL_KEY);
     if (DEBUG) logd("EVT ui_render → FE (avatar="+(string)av+", sid="+sid+", ctx="+ctx+")");
     return TRUE;
 }
 
+integer send_close_to_frontend(key av, string sid, string ctx, string reason, string origin_req_id){
+    string c = J();
+    c = JSET(c, ["type"],   T_UI_CLOSE);
+    c = JSET(c, ["from"],   "ui_backend");
+    c = JSET(c, ["to"],     "ui_frontend");
+    c = JSET(c, ["abi"],    "1");
+    if (origin_req_id != "") c = JSET(c, ["req_id"], origin_req_id);
+    if (av != NULL_KEY) c = JSET(c, ["avatar"], (string)av);
+    if (sid != "") c = JSET(c, ["session"], sid);
+    if (ctx != "") c = JSET(c, ["context"], ctx);
+    if (reason != "") c = JSET(c, ["reason"], reason);
+    llMessageLinked(LINK_SET, L_API, c, NULL_KEY);
+    if (DEBUG) logd("EVT ui_close → FE (ctx="+ctx+", reason="+reason+")");
+    return TRUE;
+}
+
 /* ---------- Open a stored context ---------- */
-integer handle_open_context(key av, string sid, string ctx){
-    string btns = menu_get(ctx);
+integer handle_open_context(key av, string sid, string ctx, string origin_req_id){
+    string use_sid = sid;
+    if (use_sid == "") use_sid = be_make_session_for(av);
+
+    string use_ctx = ctx;
+    if (use_ctx == JSON_INVALID || use_ctx == "") use_ctx = DEFAULT_CONTEXT;
+
+    string btns = menu_get(use_ctx);
     if (btns == JSON_INVALID){
-        if (DEBUG) logd("no menu for context '"+ctx+"'");
-        render_to_frontend(av, sid, ctx, "Oops", "No UI registered for '"+ctx+"'.", "[]");
+        if (DEBUG) logd("no menu for context '"+use_ctx+"'");
+        render_to_frontend(av, use_sid, use_ctx, "Oops", "No UI registered for '"+use_ctx+"'.", "[]", origin_req_id);
         return FALSE;
     }
-    return request_level_for(av, sid, ctx, "Menu", "", btns);
+    return request_level_for(av, use_sid, use_ctx, "Menu", "", btns, origin_req_id);
 }
 
 /* =============================================================
@@ -237,16 +264,56 @@ default{
             string ty = JGET(msg, ["type"]);
 
             if (ty == T_UI_TOUCH){
-                // Re-broadcast as ui_touched so plugins (CanvasDraw) can react
                 key av = (key)JGET(msg, ["avatar"]);
-                string b = J();
-                b = JSET(b, ["type"],    T_UI_TOUCHED);
-                b = JSET(b, ["from"],    "ui_backend");
-                b = JSET(b, ["to"],      "any");
-                b = JSET(b, ["abi"],     "1");
-                b = JSET(b, ["avatar"],  (string)av);
-                llMessageLinked(LINK_SET, L_BROADCAST, b, NULL_KEY);
-                if (DEBUG) logd("EVT ui_touched broadcast for "+(string)av);
+                string req = JGET(msg, ["req_id"]);
+                string sid = JGET(msg, ["session"]);
+                string ctx = JGET(msg, ["context"]);
+                if (ctx == JSON_INVALID) ctx = DEFAULT_CONTEXT;
+
+                string rid = req;
+                if (rid == JSON_INVALID) rid = "";
+
+                if (av == NULL_KEY){
+                    if (DEBUG) logd("ui_touch missing avatar");
+                    if (rid != "") send_close_to_frontend(NULL_KEY, "", DEFAULT_CONTEXT, "Missing avatar", rid);
+                    return;
+                }
+
+                handle_open_context(av, sid, ctx, rid);
+                return;
+            }
+
+            if (ty == T_UI_CLICK){
+                key avc = (key)JGET(msg, ["avatar"]);
+                string reqc = JGET(msg, ["req_id"]);
+                string sidc = JGET(msg, ["session"]);
+                string ctxc = JGET(msg, ["context"]);
+                string command = JGET(msg, ["command"]);
+                if (command == JSON_INVALID || command == "") command = JGET(msg, ["feature_id"]);
+
+                string ridc = reqc;
+                if (ridc == JSON_INVALID) ridc = "";
+
+                if (avc == NULL_KEY){
+                    if (DEBUG) logd("ui_click missing avatar");
+                    if (ridc != "") send_close_to_frontend(NULL_KEY, "", DEFAULT_CONTEXT, "Missing avatar", ridc);
+                    return;
+                }
+
+                string use_ctx = ctxc;
+                if (use_ctx == JSON_INVALID || use_ctx == "") use_ctx = DEFAULT_CONTEXT;
+
+                if (command == JSON_INVALID || command == ""){
+                    render_to_frontend(avc, sidc, use_ctx, "Unhandled", "No command provided.", "[]", ridc);
+                    return;
+                }
+
+                if (menu_get(command) != JSON_INVALID){
+                    handle_open_context(avc, sidc, command, ridc);
+                    return;
+                }
+
+                render_to_frontend(avc, sidc, use_ctx, "Unhandled", "No handler for '"+command+"'.", "[]", ridc);
                 return;
             }
 
@@ -269,13 +336,13 @@ default{
                 // Ask ACL, then render
                 key    av  = (key)JGET(payload, ["avatar"]);
                 string sid =      JGET(payload, ["session"]);
-                string ctx =      JGET(payload, ["context"]); if (ctx == JSON_INVALID) ctx = "home";
+                string ctx =      JGET(payload, ["context"]); if (ctx == JSON_INVALID) ctx = DEFAULT_CONTEXT;
                 string t   =      JGET(payload, ["title"]);   if (t   == JSON_INVALID) t   = "Menu";
                 string bdy =      JGET(payload, ["body"]);    if (bdy == JSON_INVALID) bdy = "";
                 string btns =     JGET(payload, ["buttons"]); if (btns== JSON_INVALID) btns= "[]";
 
                 if (av == NULL_KEY){ if (DEBUG) logd("ui_draw missing avatar"); return; }
-                request_level_for(av, sid, ctx, t, bdy, btns);
+                request_level_for(av, sid, ctx, t, bdy, btns, "");
                 return;
             }
 
@@ -285,8 +352,11 @@ default{
                 string ctx= JGET(msg, ["context"]); if (ctx == JSON_INVALID) ctx = "message";
                 string t  = JGET(msg, ["title"]);   if (t   == JSON_INVALID) t   = "Info";
                 string m  = JGET(msg, ["message"]); if (m   == JSON_INVALID) m   = "";
-                string ok = llList2Json(JSON_ARRAY, [ JSET(J(), ["label"], "OK"), JSET(J(), ["id"], "ok") ]);
-                render_to_frontend(av, sid, ctx, t, m, llList2Json(JSON_ARRAY, [ JSET(J(), ["label"], "OK"), JSET(J(), ["id"], "ok") ]));
+                string ridm = JGET(msg, ["req_id"]);
+                string okButton = JSET(JSET(J(), ["label"], "OK"), ["id"], "ok");
+                string buttons = llList2Json(JSON_ARRAY, [okButton]);
+                if (ridm == JSON_INVALID) ridm = "";
+                render_to_frontend(av, sid, ctx, t, m, buttons, ridm);
                 return;
             }
 
@@ -301,30 +371,16 @@ default{
                 string t   =       llList2String(row, 4);
                 string bdy =       llList2String(row, 5);
                 string btns=       llList2String(row, 6);
+                string origin_req = llList2String(row, 7);
 
                 integer level = (integer)JGET(msg, ["level"]);
                 string filtered = filter_buttons_by_level(btns, level);
-                render_to_frontend(av, sid, ctx, t, bdy, filtered);
+                render_to_frontend(av, sid, ctx, t, bdy, filtered, origin_req);
                 return;
             }
 
             return;
         }
 
-        /* --------- Broadcasts (optional context open) --------- */
-        if (num == L_BROADCAST){
-            string ty = JGET(msg, ["type"]);
-            if (ty == T_UI_BUTTON){
-                key    av  = (key)JGET(msg, ["avatar"]);
-                string fid =       JGET(msg, ["feature_id"]);
-                // If a button id equals a known context, open it here
-                if (menu_get(fid) != JSON_INVALID){
-                    // No session provided here; FE/API will maintain per-avatar session
-                    handle_open_context(av, "", fid);
-                    return;
-                }
-            }
-            return;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- update the experimental UI frontend to send req_id-bearing ui_touch/ui_click requests directly to the backend
- refactor the experimental UI backend to obey the experimental lane map, reply on the same req_id, and provide graceful fallbacks when no menu is registered
- add request-aware helpers so ACL-filtered renders and error closes satisfy the API router expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d39247b4b8832ba8580d5d7a67496d