### PR TITLE
Protect auth ACL replies until settings ready and honor plugin returns

### DIFF
--- a/src/stable/modules/ds_collar_kmod_ui.lsl
+++ b/src/stable/modules/ds_collar_kmod_ui.lsl
@@ -461,10 +461,30 @@ default{
         }
 
         if (num == K_PLUGIN_RETURN_NUM){
-            if (llJsonValueType(msg,["context"]) != JSON_INVALID){
-                string ctx = llJsonGetValue(msg,["context"]);
-                if (ctx == ROOT_CONTEXT) showRoot(User, Page);
+            if (llJsonValueType(msg,["context"]) == JSON_INVALID) return;
+
+            string ctx = llJsonGetValue(msg,["context"]);
+            if (ctx != ROOT_CONTEXT) return;
+
+            if (id == NULL_KEY) return;
+
+            if (id != User){
+                //PATCH honor returning avatar; rebuild their session safely
+                User = id;
+                if (DialogOpen) closeDialog();
+
+                AclReady = FALSE; ListReady = FALSE;
+                Acl = -1; IsWearer = FALSE; OwnerSet = FALSE;
+                PolTpe = FALSE; PolPublicOnly = FALSE; PolOwnedOnly = FALSE;
+                PolTrusteeAccess = FALSE; PolWearerUnowned = FALSE; PolPrimaryOwner = FALSE;
+                Page = 0;
+
+                queryAcl(User);
+                fetchRegistry();
+                return;
             }
+
+            showRoot(User, Page);
             return;
         }
     }


### PR DESCRIPTION
## Summary
- defer ACL answers in kmod_auth until a settings snapshot has been applied and replay any queued requests afterwards
- honor the avatar id on plugin_return events by rebuilding sessions for returning users instead of reopening dialogs for the wrong wearer
- allow queue_register to refresh existing plugins and cancel stale deregistration requests so re-registering plugins remain listed

## Testing
- not run (LSL environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3daab5688832b9a926c72a9ff97fe