### PR TITLE
Fix API routing loop and bootstrap request IDs

### DIFF
--- a/src/experimental/ds_collar_api.lsl
+++ b/src/experimental/ds_collar_api.lsl
@@ -34,6 +34,8 @@ integer IsRequest(string t){
 
 /* Map "to" → lane */
 integer lane_for_module(string mod){
+    if (mod == "") return 0;
+    if (mod == "api") return 0;
     if (mod == "ui_backend")  return L_UI_BE_IN;
     if (mod == "ui_frontend") return L_UI_FE_IN;
     /* Default: route through API lane */
@@ -89,6 +91,8 @@ integer emit_error(string toMod, string reqId, string code, string message){
 }
 
 integer forward_to_module(string payload, string toMod){
+    if (toMod == "") return FALSE;
+    if (toMod == "api") return TRUE;
     integer lane = lane_for_module(toMod);
     if (lane == 0) return FALSE;
     llMessageLinked(LINK_SET, lane, payload, NULL_KEY);
@@ -160,6 +164,10 @@ default{
         }
 
         if (toMod != ""){
+            if (toMod == "api"){
+                logd("EVT " + t + " " + fromMod + "→api (local)");
+                return;
+            }
             integer ok3 = forward_to_module(msg, toMod);
             if (!ok3){
                 emit_error(fromMod, reqId, "E_NOTFOUND", "Unknown 'to'");

--- a/src/experimental/ds_collar_kmod_bootstrap.lsl
+++ b/src/experimental/ds_collar_kmod_bootstrap.lsl
@@ -39,6 +39,7 @@ string PATH_OWNER_HON = "core.owner.hon";
 
 /* ---------- State ---------- */
 string  BootId;
+integer ReqSeq;
 
 /* Owner state + name resolution */
 key    OwnerKey;
@@ -89,6 +90,14 @@ string mk_boot_id(){
     return (string)t + "-" + (string)llRound(r) + "-" + shortOwner;
 }
 
+string next_req_id(string tag){
+    if (BootId == "") BootId = mk_boot_id();
+    ReqSeq += 1;
+    string rid = "boot-" + BootId + "-" + (string)ReqSeq;
+    if (tag != "") rid += "-" + tag;
+    return rid;
+}
+
 /* JSON array push */
 string json_array_push(string arr, string obj){
     integer i = 0;
@@ -104,7 +113,7 @@ integer api_send(string toMod, string type, list kv){
     j = llJsonSetValue(j, ["type"], type);
     j = llJsonSetValue(j, ["from"], "bootstrap");
     j = llJsonSetValue(j, ["to"], toMod);
-    j = llJsonSetValue(j, ["req_id"], (string)now());
+    j = llJsonSetValue(j, ["req_id"], next_req_id(type));
 
     integer i = 0;
     integer n = llGetListLength(kv);
@@ -159,7 +168,7 @@ integer store_display_name(string uuid, string name){
     j = llJsonSetValue(j, ["type"], TYPE_DISPLAY_NAME_UPDATE);
     j = llJsonSetValue(j, ["from"], "bootstrap");
     j = llJsonSetValue(j, ["to"], "settings");
-    j = llJsonSetValue(j, ["req_id"], (string)now());
+    j = llJsonSetValue(j, ["req_id"], next_req_id("name"));
     j = llJsonSetValue(j, ["uuid"], llToLower(uuid));
     j = llJsonSetValue(j, ["name"], name);
     llMessageLinked(LINK_SET, L_API, j, NULL_KEY);
@@ -364,6 +373,7 @@ integer rlv_finish_and_persist(){
 default{
     state_entry(){
         PendingNames = [];
+        ReqSeq = 0;
         BootId = mk_boot_id();
 
         publish_boot_runtime();


### PR DESCRIPTION
## Summary
- prevent the API router from re-forwarding messages addressed to itself by treating `to:"api"` as a local delivery
- generate monotonic, boot-scoped request identifiers in the bootstrapper instead of timestamp strings

## Testing
- not run (LSL scripts)


------
https://chatgpt.com/codex/tasks/task_e_68d45d2759dc832b8326a5bfd2b6b092