### PR TITLE
Add future root UI plugin with ACL-gated menu

### DIFF
--- a/src/future/ds_collar_kernel.lsl
+++ b/src/future/ds_collar_kernel.lsl
@@ -1,0 +1,414 @@
+/* =============================================================
+   MODULE: ds_collar_kernel.lsl
+   ROLE  : Base kernel for DS Collar modular system.
+           - Maintains plugin registry and serializes register/deregister flows.
+           - Supervises heartbeat/liveness using ping/pong and inventory presence.
+           - Broadcasts plugin list snapshots and re-solicits registrations on resets.
+           - Guards inbound payloads and fails closed on malformed inputs.
+   ============================================================= */
+
+integer DEBUG = FALSE;
+
+/* ---------- Message Types ---------- */
+string MSG_REGISTER        = "register";
+string MSG_REGISTER_NOW    = "register_now";
+string MSG_DEREGISTER      = "deregister";
+string MSG_PLUGIN_LIST     = "plugin_list";
+string MSG_PLUGIN_START    = "plugin_start";
+string MSG_PLUGIN_RETURN   = "plugin_return";
+string MSG_KERNEL_SOFT_RST = "kernel_soft_reset";
+string MSG_SOFT_RESET      = "plugin_soft_reset";
+string MSG_PING            = "plugin_ping";
+string MSG_PONG            = "plugin_pong";
+string MSG_SETTINGS_GET    = "settings_get";
+string MSG_SETTINGS_SYNC   = "settings_sync";
+string MSG_AUTH_QUERY      = "acl_query";
+string MSG_AUTH_RESULT     = "acl_result";
+
+/* ---------- Link Numbers ---------- */
+integer K_PLUGIN_REG_QUERY     = 500;
+integer K_PLUGIN_REG_REPLY     = 501;
+integer K_PLUGIN_DEREG         = 502;
+integer K_SOFT_RESET           = 503;
+integer K_PLUGIN_SOFT_RESET    = 504;
+integer K_PLUGIN_LIST          = 600;
+integer K_PLUGIN_LIST_REQUEST  = 601;
+integer K_PLUGIN_START         = 900;
+integer K_PLUGIN_RETURN        = 901;
+integer K_PLUGIN_PING          = 650;
+integer K_PLUGIN_PONG          = 651;
+
+/* ---------- Settings & Auth ---------- */
+integer SETTINGS_QUERY_NUM     = 800;
+integer SETTINGS_SYNC_NUM      = 870;
+integer AUTH_QUERY_NUM         = 700;
+integer AUTH_RESULT_NUM        = 710;
+
+/* ---------- Heartbeat Timing ---------- */
+float   TIMER_TICK_SEC   = 0.25;
+float   PING_INTERVAL    = 5.0;
+integer PING_TIMEOUT_SEC = 15;
+float   INV_SWEEP_SEC    = 3.0;
+
+/* ---------- Registry bookkeeping ---------- */
+/* stride = 7: [context, isn, sn, label, min_acl, script, last_seen_unix] */
+list    PluginMap   = [];
+list    AddQueue    = [];
+list    DeregQueue  = [];
+integer NextIsn     = 1;
+integer Registering = FALSE;
+integer Dereging    = FALSE;
+
+integer LastPingUnix    = 0;
+integer LastSweepUnix   = 0;
+key     CachedOwner     = NULL_KEY;
+
+/* ---------- Helpers ---------- */
+integer logd(string msg){ if (DEBUG) llOwnerSay("[KERNEL] " + msg); return FALSE; }
+integer now(){ return llGetUnixTime(); }
+integer stride(){ return 7; }
+
+integer json_has(string j, list path){ if (llJsonGetValue(j, path) == JSON_INVALID) return FALSE; return TRUE; }
+
+integer map_index_from_context(string ctx){
+    integer s = stride();
+    integer i = 0;
+    integer n = llGetListLength(PluginMap);
+    while (i < n){
+        if (llList2String(PluginMap, i) == ctx) return i;
+        i += s;
+    }
+    return -1;
+}
+
+integer map_touch(string ctx, integer when){
+    integer idx = map_index_from_context(ctx);
+    if (idx == -1) return FALSE;
+    PluginMap = llListReplaceList(PluginMap, [
+        llList2String (PluginMap, idx),
+        llList2Integer(PluginMap, idx + 1),
+        llList2Integer(PluginMap, idx + 2),
+        llList2String (PluginMap, idx + 3),
+        llList2Integer(PluginMap, idx + 4),
+        llList2String (PluginMap, idx + 5),
+        when
+    ], idx, idx + 6);
+    return TRUE;
+}
+
+integer queue_register(string ctx, integer sn, string label, integer min_acl, string script){
+    if (ctx == "") return FALSE;
+    integer existing = llListFindList(AddQueue, [ctx]);
+    if (existing != -1){
+        AddQueue = llListReplaceList(AddQueue, [ctx, sn, label, min_acl, script], existing, existing + 4);
+        Registering = TRUE;
+        return TRUE;
+    }
+    integer pending_drop = llListFindList(DeregQueue, [ctx]);
+    if (pending_drop != -1){
+        DeregQueue = llDeleteSubList(DeregQueue, pending_drop, pending_drop);
+        if (llGetListLength(DeregQueue) == 0) Dereging = FALSE;
+    }
+    AddQueue += [ctx, sn, label, min_acl, script];
+    Registering = TRUE;
+    return TRUE;
+}
+
+integer queue_deregister(string ctx){
+    if (ctx == "") return FALSE;
+    if (map_index_from_context(ctx) == -1) return FALSE;
+    if (llListFindList(DeregQueue, [ctx]) != -1) return FALSE;
+    DeregQueue += [ctx];
+    Dereging = TRUE;
+    return TRUE;
+}
+
+integer process_next_add(){
+    if (llGetListLength(AddQueue) == 0){
+        if (Registering){
+            Registering = FALSE;
+            broadcast_plugin_list();
+        }
+        return FALSE;
+    }
+    string  ctx     = llList2String (AddQueue, 0);
+    integer sn      = llList2Integer(AddQueue, 1);
+    string  label   = llList2String (AddQueue, 2);
+    integer min_acl = llList2Integer(AddQueue, 3);
+    string  script  = llList2String (AddQueue, 4);
+    AddQueue = llDeleteSubList(AddQueue, 0, 4);
+
+    if (ctx == "") return TRUE;
+    integer idx = map_index_from_context(ctx);
+    integer ts  = now();
+    if (script == "") script = ctx;
+
+    if (idx == -1){
+        integer isn = NextIsn;
+        NextIsn += 1;
+        PluginMap += [ctx, isn, sn, label, min_acl, script, ts];
+        logd("Registered " + ctx + " isn=" + (string)isn);
+    } else {
+        integer old_isn = llList2Integer(PluginMap, idx + 1);
+        PluginMap = llListReplaceList(PluginMap, [ctx, old_isn, sn, label, min_acl, script, ts], idx, idx + 6);
+        logd("Refreshed " + ctx);
+    }
+    return TRUE;
+}
+
+integer process_next_dereg(){
+    if (llGetListLength(DeregQueue) == 0){
+        if (Dereging){
+            Dereging = FALSE;
+            broadcast_plugin_list();
+        }
+        return FALSE;
+    }
+    string ctx = llList2String(DeregQueue, 0);
+    DeregQueue = llDeleteSubList(DeregQueue, 0, 0);
+    integer idx = map_index_from_context(ctx);
+    if (idx == -1) return TRUE;
+
+    string j = llList2Json(JSON_OBJECT, []);
+    j = llJsonSetValue(j, ["type"], MSG_DEREGISTER);
+    j = llJsonSetValue(j, ["context"], ctx);
+    llMessageLinked(LINK_SET, K_PLUGIN_DEREG, j, NULL_KEY);
+    PluginMap = llDeleteSubList(PluginMap, idx, idx + 6);
+    logd("Deregistered " + ctx);
+    return TRUE;
+}
+
+integer broadcast_plugin_list(){
+    integer s = stride();
+    integer i = 0;
+    integer n = llGetListLength(PluginMap);
+    list arr = [];
+    while (i < n){
+        string ctx     = llList2String (PluginMap, i);
+        integer isn    = llList2Integer(PluginMap, i + 1);
+        integer sn     = llList2Integer(PluginMap, i + 2);
+        string label   = llList2String (PluginMap, i + 3);
+        integer min_acl= llList2Integer(PluginMap, i + 4);
+        string payload = llList2Json(JSON_OBJECT, []);
+        payload = llJsonSetValue(payload, ["context"], ctx);
+        payload = llJsonSetValue(payload, ["isn"], (string)isn);
+        payload = llJsonSetValue(payload, ["sn"], (string)sn);
+        payload = llJsonSetValue(payload, ["label"], label);
+        payload = llJsonSetValue(payload, ["min_acl"], (string)min_acl);
+        arr += [payload];
+        i += s;
+    }
+    string j = llList2Json(JSON_OBJECT, []);
+    j = llJsonSetValue(j, ["type"], MSG_PLUGIN_LIST);
+    j = llJsonSetValue(j, ["plugins"], llList2Json(JSON_ARRAY, arr));
+    llMessageLinked(LINK_SET, K_PLUGIN_LIST, j, NULL_KEY);
+    return llGetListLength(arr);
+}
+
+integer solicit_plugin_register(){
+    integer count = llGetInventoryNumber(INVENTORY_SCRIPT);
+    integer i = 0;
+    while (i < count){
+        string script_name = llGetInventoryName(INVENTORY_SCRIPT, i);
+        if (script_name != llGetScriptName()){
+            if (llSubStringIndex(script_name, "ds_collar_plugin_") == 0){
+                string j = llList2Json(JSON_OBJECT, []);
+                j = llJsonSetValue(j, ["type"], MSG_REGISTER_NOW);
+                j = llJsonSetValue(j, ["script"], script_name);
+                llMessageLinked(LINK_SET, K_PLUGIN_REG_QUERY, j, NULL_KEY);
+            }
+        }
+        i += 1;
+    }
+    return TRUE;
+}
+
+integer send_ping_all(){
+    integer s = stride();
+    integer i = 0;
+    integer n = llGetListLength(PluginMap);
+    integer ts = now();
+    while (i < n){
+        string ctx = llList2String(PluginMap, i);
+        string j = llList2Json(JSON_OBJECT, []);
+        j = llJsonSetValue(j, ["type"], MSG_PING);
+        j = llJsonSetValue(j, ["context"], ctx);
+        j = llJsonSetValue(j, ["ts"], (string)ts);
+        llMessageLinked(LINK_SET, K_PLUGIN_PING, j, NULL_KEY);
+        i += s;
+    }
+    return TRUE;
+}
+
+integer prune_dead_plugins(){
+    integer s = stride();
+    integer i = 0;
+    integer n = llGetListLength(PluginMap);
+    integer ts = now();
+    integer removed = FALSE;
+    while (i < n){
+        string ctx    = llList2String (PluginMap, i);
+        integer seen  = llList2Integer(PluginMap, i + 6);
+        string script = llList2String (PluginMap, i + 5);
+        if (script == "") script = ctx;
+        integer in_inv = (llGetInventoryType(script) == INVENTORY_SCRIPT);
+        integer fresh  = ((ts - seen) <= PING_TIMEOUT_SEC);
+        if (!in_inv && !fresh){
+            PluginMap = llDeleteSubList(PluginMap, i, i + 6);
+            n -= s;
+            removed = TRUE;
+            logd("Pruned " + ctx);
+        } else {
+            i += s;
+        }
+    }
+    if (removed) broadcast_plugin_list();
+    return removed;
+}
+
+integer handle_soft_reset(string payload){
+    PluginMap = [];
+    AddQueue = [];
+    DeregQueue = [];
+    NextIsn = 1;
+    Registering = FALSE;
+    Dereging = FALSE;
+    LastPingUnix = now();
+    LastSweepUnix = LastPingUnix;
+    broadcast_plugin_list();
+    solicit_plugin_register();
+    return TRUE;
+}
+
+integer owner_changed(){
+    key cur = llGetOwner();
+    if (cur == NULL_KEY) return FALSE;
+    if (cur != CachedOwner){
+        CachedOwner = cur;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/* ---------- Events ---------- */
+default
+{
+    state_entry(){
+        CachedOwner = llGetOwner();
+        PluginMap = [];
+        AddQueue = [];
+        DeregQueue = [];
+        NextIsn = 1;
+        Registering = FALSE;
+        Dereging = FALSE;
+        LastPingUnix = now();
+        LastSweepUnix = LastPingUnix;
+        llSetTimerEvent(TIMER_TICK_SEC);
+        solicit_plugin_register();
+    }
+
+    on_rez(integer start_param){
+        if (owner_changed()) llResetScript();
+    }
+
+    attach(key id){
+        if (id == NULL_KEY) return;
+        if (owner_changed()) llResetScript();
+    }
+
+    changed(integer change){
+        if (change & CHANGED_OWNER){
+            if (owner_changed()) llResetScript();
+        }
+        if (change & CHANGED_INVENTORY){
+            prune_dead_plugins();
+            solicit_plugin_register();
+        }
+    }
+
+    link_message(integer sender, integer num, string str, key id){
+        if (num == K_PLUGIN_LIST_REQUEST){
+            broadcast_plugin_list();
+            return;
+        }
+        if (num == K_SOFT_RESET){
+            integer accept = FALSE;
+            if (str == MSG_KERNEL_SOFT_RST) accept = TRUE;
+            else if (json_has(str, ["type"])){
+                if (llJsonGetValue(str, ["type"]) == MSG_KERNEL_SOFT_RST) accept = TRUE;
+            }
+            if (accept){
+                handle_soft_reset(str);
+            }
+            return;
+        }
+        if (num == K_PLUGIN_SOFT_RESET){
+            if (!json_has(str, ["type"])) return;
+            if (llJsonGetValue(str, ["type"]) != MSG_SOFT_RESET) return;
+            string ctx = "";
+            if (json_has(str, ["context"])) ctx = llJsonGetValue(str, ["context"]);
+            if (ctx != ""){
+                map_touch(ctx, now());
+                if (map_index_from_context(ctx) == -1){
+                    string script = ctx;
+                    if (json_has(str, ["script"])) script = llJsonGetValue(str, ["script"]);
+                    string j = llList2Json(JSON_OBJECT, []);
+                    j = llJsonSetValue(j, ["type"], MSG_REGISTER_NOW);
+                    j = llJsonSetValue(j, ["script"], script);
+                    llMessageLinked(LINK_SET, K_PLUGIN_REG_QUERY, j, NULL_KEY);
+                }
+            }
+            return;
+        }
+        if (num == K_PLUGIN_REG_REPLY){
+            if (!json_has(str, ["type"])) return;
+            if (llJsonGetValue(str, ["type"]) != MSG_REGISTER) return;
+            if (!json_has(str, ["context"])) return;
+            string ctx = llJsonGetValue(str, ["context"]);
+            integer sn = 0;
+            string label = "";
+            integer min_acl = 0;
+            if (json_has(str, ["sn"])) sn = (integer)llJsonGetValue(str, ["sn"]);
+            if (json_has(str, ["label"])) label = llJsonGetValue(str, ["label"]);
+            if (json_has(str, ["min_acl"])) min_acl = (integer)llJsonGetValue(str, ["min_acl"]);
+            string script = "";
+            if (json_has(str, ["script"])) script = llJsonGetValue(str, ["script"]);
+            queue_register(ctx, sn, label, min_acl, script);
+            return;
+        }
+        if (num == K_PLUGIN_DEREG){
+            if (!json_has(str, ["type"])) return;
+            if (llJsonGetValue(str, ["type"]) != MSG_DEREGISTER) return;
+            if (!json_has(str, ["context"])) return;
+            queue_deregister(llJsonGetValue(str, ["context"]));
+            return;
+        }
+        if (num == K_PLUGIN_PONG){
+            if (!json_has(str, ["type"])) return;
+            if (llJsonGetValue(str, ["type"]) != MSG_PONG) return;
+            if (!json_has(str, ["context"])) return;
+            map_touch(llJsonGetValue(str, ["context"]), now());
+            return;
+        }
+    }
+
+    timer(){
+        if (Registering){
+            process_next_add();
+            return;
+        }
+        if (Dereging){
+            process_next_dereg();
+            return;
+        }
+        integer ts = now();
+        if ((ts - LastPingUnix) >= (integer)PING_INTERVAL){
+            send_ping_all();
+            LastPingUnix = ts;
+        }
+        if ((ts - LastSweepUnix) >= (integer)INV_SWEEP_SEC){
+            prune_dead_plugins();
+            LastSweepUnix = ts;
+        }
+    }
+}

--- a/src/future/modules/ds_collar_kmod_auth.lsl
+++ b/src/future/modules/ds_collar_kmod_auth.lsl
@@ -1,0 +1,230 @@
+/* =============================================================
+   MODULE: ds_collar_kmod_auth.lsl
+   ROLE  : Authorization authority.
+           - Consumes settings snapshots and resolves ACL levels.
+           - Replies to AUTH queries with policy flags and wearer context.
+           - Caches lookups and replays queued requests once settings are ready.
+   ============================================================= */
+
+integer DEBUG = FALSE;
+
+/* ---------- Message Types ---------- */
+string MSG_SETTINGS_GET   = "settings_get";
+string MSG_SETTINGS_SYNC  = "settings_sync";
+string MSG_AUTH_QUERY     = "acl_query";
+string MSG_AUTH_RESULT    = "acl_result";
+
+/* ---------- Link numbers ---------- */
+integer SETTINGS_QUERY_NUM = 800;
+integer SETTINGS_SYNC_NUM  = 870;
+integer AUTH_QUERY_NUM     = 700;
+integer AUTH_RESULT_NUM    = 710;
+
+/* ---------- Settings keys ---------- */
+string KEY_OWNER_KEY     = "owner_key";
+string KEY_TRUSTEES      = "trustees";
+string KEY_BLACKLIST     = "blacklist";
+string KEY_PUBLIC_ACCESS = "public_mode";
+string KEY_TPE_MODE      = "tpe_mode";
+
+/* ---------- ACL levels ---------- */
+integer ACL_BLACKLIST     = -1;
+integer ACL_NOACCESS      = 0;
+integer ACL_PUBLIC        = 1;
+integer ACL_OWNED         = 2;
+integer ACL_TRUSTEE       = 3;
+integer ACL_UNOWNED       = 4;
+integer ACL_PRIMARY_OWNER = 5;
+
+/* ---------- Cached state ---------- */
+key     OwnerKey       = NULL_KEY;
+list    TrusteeList    = [];
+list    BlacklistList  = [];
+integer PublicMode     = FALSE;
+integer TpeMode        = FALSE;
+integer SettingsReady  = FALSE;
+list    PendingQueries = [];
+key     LastOwner      = NULL_KEY;
+
+/* ---------- Helpers ---------- */
+integer logd(string msg){ if (DEBUG) llOwnerSay("[AUTH] " + msg); return FALSE; }
+integer json_has(string j, list path){ if (llJsonGetValue(j, path) == JSON_INVALID) return FALSE; return TRUE; }
+integer is_json_obj(string s){ if (llGetSubString(s, 0, 0) == "{") return TRUE; return FALSE; }
+integer is_json_arr(string s){ if (llGetSubString(s, 0, 0) == "[") return TRUE; return FALSE; }
+
+list json_arr_to_list(string s){ if (!is_json_arr(s)) return []; return llJson2List(s); }
+integer list_has(list L, string s){ if (llListFindList(L, [s]) != -1) return TRUE; return FALSE; }
+
+integer queue_acl_request(key av){
+    if (av == NULL_KEY) return FALSE;
+    PendingQueries += [(string)av];
+    return TRUE;
+}
+
+integer request_settings(){
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_SETTINGS_GET);
+    llMessageLinked(LINK_SET, SETTINGS_QUERY_NUM, payload, NULL_KEY);
+    return TRUE;
+}
+
+integer compute_acl(key av){
+    key wearer = llGetOwner();
+    integer owner_set = FALSE;
+    if (OwnerKey != NULL_KEY) owner_set = TRUE;
+
+    integer is_owner = FALSE;
+    integer is_wearer = FALSE;
+    integer is_trustee = FALSE;
+    integer is_black = FALSE;
+
+    if (owner_set && av == OwnerKey) is_owner = TRUE;
+    if (av == wearer) is_wearer = TRUE;
+    if (!is_owner && !is_wearer){
+        if (list_has(TrusteeList, (string)av)) is_trustee = TRUE;
+        if (list_has(BlacklistList, (string)av)) is_black = TRUE;
+    }
+
+    if (is_owner) return ACL_PRIMARY_OWNER;
+    if (is_wearer){
+        if (TpeMode) return ACL_NOACCESS;
+        if (owner_set) return ACL_OWNED;
+        return ACL_UNOWNED;
+    }
+    if (is_trustee) return ACL_TRUSTEE;
+    if (is_black) return ACL_BLACKLIST;
+    if (PublicMode) return ACL_PUBLIC;
+    return ACL_BLACKLIST;
+}
+
+integer send_acl_result(key av, integer level){
+    key wearer = llGetOwner();
+    integer is_wearer = FALSE;
+    if (av == wearer) is_wearer = TRUE;
+    integer owner_set = FALSE;
+    if (OwnerKey != NULL_KEY) owner_set = TRUE;
+
+    integer policy_tpe            = 0;
+    integer policy_public_only    = 0;
+    integer policy_owned_only     = 0;
+    integer policy_trustee_access = 0;
+    integer policy_wearer_unowned = 0;
+    integer policy_primary_owner  = 0;
+
+    if (is_wearer){
+        if (TpeMode) policy_tpe = 1;
+        else {
+            if (owner_set) policy_owned_only = 1;
+            else policy_wearer_unowned = 1;
+        }
+        if (!owner_set) policy_trustee_access = 1;
+    } else {
+        if (PublicMode) policy_public_only = 1;
+        if (level == ACL_TRUSTEE) policy_trustee_access = 1;
+        if (level == ACL_PRIMARY_OWNER) policy_primary_owner = 1;
+    }
+
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_AUTH_RESULT);
+    payload = llJsonSetValue(payload, ["avatar"], (string)av);
+    payload = llJsonSetValue(payload, ["level"], (string)level);
+    payload = llJsonSetValue(payload, ["is_wearer"], (string)is_wearer);
+    payload = llJsonSetValue(payload, ["owner_set"], (string)owner_set);
+    payload = llJsonSetValue(payload, ["policy_tpe"], (string)policy_tpe);
+    payload = llJsonSetValue(payload, ["policy_public_only"], (string)policy_public_only);
+    payload = llJsonSetValue(payload, ["policy_owned_only"], (string)policy_owned_only);
+    payload = llJsonSetValue(payload, ["policy_trustee_access"], (string)policy_trustee_access);
+    payload = llJsonSetValue(payload, ["policy_wearer_unowned"], (string)policy_wearer_unowned);
+    payload = llJsonSetValue(payload, ["policy_primary_owner"], (string)policy_primary_owner);
+    llMessageLinked(LINK_SET, AUTH_RESULT_NUM, payload, av);
+    return TRUE;
+}
+
+integer apply_settings(string payload){
+    if (!json_has(payload, ["type"])) return FALSE;
+    if (llJsonGetValue(payload, ["type"]) != MSG_SETTINGS_SYNC) return FALSE;
+    if (!json_has(payload, ["kv"])) return FALSE;
+    string kv = llJsonGetValue(payload, ["kv"]);
+    if (!is_json_obj(kv)) return FALSE;
+
+    OwnerKey      = NULL_KEY;
+    TrusteeList   = [];
+    BlacklistList = [];
+    PublicMode    = FALSE;
+    TpeMode       = FALSE;
+
+    if (json_has(kv, [KEY_OWNER_KEY])) OwnerKey = (key)llJsonGetValue(kv, [KEY_OWNER_KEY]);
+    if (json_has(kv, [KEY_TRUSTEES])) TrusteeList = json_arr_to_list(llJsonGetValue(kv, [KEY_TRUSTEES]));
+    if (json_has(kv, [KEY_BLACKLIST])) BlacklistList = json_arr_to_list(llJsonGetValue(kv, [KEY_BLACKLIST]));
+    if (json_has(kv, [KEY_PUBLIC_ACCESS])) PublicMode = (integer)llJsonGetValue(kv, [KEY_PUBLIC_ACCESS]);
+    if (json_has(kv, [KEY_TPE_MODE])) TpeMode = (integer)llJsonGetValue(kv, [KEY_TPE_MODE]);
+
+    SettingsReady = TRUE;
+    logd("settings applied");
+
+    integer i = 0;
+    integer n = llGetListLength(PendingQueries);
+    while (i < n){
+        key av = (key)llList2String(PendingQueries, i);
+        if (av != NULL_KEY){
+            integer lvl = compute_acl(av);
+            send_acl_result(av, lvl);
+        }
+        i += 1;
+    }
+    PendingQueries = [];
+    return TRUE;
+}
+
+/* ---------- Events ---------- */
+default
+{
+    state_entry(){
+        LastOwner = llGetOwner();
+        SettingsReady = FALSE;
+        PendingQueries = [];
+        request_settings();
+    }
+
+    on_rez(integer start_param){
+        if (llGetOwner() != LastOwner) llResetScript();
+    }
+
+    attach(key id){
+        if (id == NULL_KEY) return;
+        if (llGetOwner() != LastOwner) llResetScript();
+    }
+
+    changed(integer change){
+        if (change & CHANGED_OWNER){
+            if (llGetOwner() != LastOwner) llResetScript();
+        }
+    }
+
+    link_message(integer sender, integer num, string str, key id){
+        if (num == SETTINGS_SYNC_NUM){
+            apply_settings(str);
+            return;
+        }
+        if (num == AUTH_QUERY_NUM){
+            if (!json_has(str, ["type"])) return;
+            if (llJsonGetValue(str, ["type"]) != MSG_AUTH_QUERY) return;
+            if (!json_has(str, ["avatar"])) return;
+            key av = (key)llJsonGetValue(str, ["avatar"]);
+            if (SettingsReady){
+                integer level = compute_acl(av);
+                send_acl_result(av, level);
+            } else {
+                queue_acl_request(av);
+                request_settings();
+            }
+            return;
+        }
+        if (num == SETTINGS_QUERY_NUM){
+            if (!json_has(str, ["type"])) return;
+            if (llJsonGetValue(str, ["type"]) != MSG_SETTINGS_SYNC) return;
+            apply_settings(str);
+            return;
+        }
+    }
+}

--- a/src/future/modules/ds_collar_kmod_bootstrap.lsl
+++ b/src/future/modules/ds_collar_kmod_bootstrap.lsl
@@ -1,0 +1,253 @@
+/* =============================================================
+   MODULE: ds_collar_kmod_bootstrap.lsl
+   ROLE  : Bootstrapper and liveness supervisor for DS Collar.
+           - Drives initial kernel/module synchronization on rez/attach.
+           - Waits for plugin list, settings, and auth readiness with single timer.
+           - Retries via kernel soft reset when acknowledgements stall.
+   ============================================================= */
+
+integer DEBUG = FALSE;
+
+/* ---------- Link numbers ---------- */
+integer K_SOFT_RESET          = 503;
+integer K_PLUGIN_LIST         = 600;
+integer K_PLUGIN_LIST_REQUEST = 601;
+integer K_PLUGIN_PING         = 650;
+integer K_PLUGIN_PONG         = 651;
+integer K_PLUGIN_START        = 900;
+integer K_PLUGIN_RETURN       = 901;
+integer SETTINGS_QUERY_NUM    = 800;
+integer SETTINGS_SYNC_NUM     = 870;
+integer AUTH_QUERY_NUM        = 700;
+integer AUTH_RESULT_NUM       = 710;
+
+/* ---------- Message types ---------- */
+string MSG_KERNEL_SOFT_RST = "kernel_soft_reset";
+string MSG_PLUGIN_LIST     = "plugin_list";
+string MSG_SETTINGS_SYNC   = "settings_sync";
+string MSG_AUTH_QUERY      = "acl_query";
+string MSG_AUTH_RESULT     = "acl_result";
+string MSG_PLUGIN_START    = "plugin_start";
+
+/* ---------- Timing ---------- */
+float   TIMER_TICK_SEC      = 0.5;
+integer BOOT_RETRY_SEC      = 10;
+integer HEARTBEAT_TIMEOUT   = 60;
+
+/* ---------- State ---------- */
+integer BootActive      = FALSE;
+integer WaitPluginList  = FALSE;
+integer WaitSettings    = FALSE;
+integer WaitAuth        = FALSE;
+integer BootDeadline    = 0;
+integer BootAttempts    = 0;
+integer MaxBootAttempts = 3;
+integer LastKernelPing  = 0;
+key     LastOwner       = NULL_KEY;
+
+/* ---------- Helpers ---------- */
+integer logd(string msg){ if (DEBUG) llOwnerSay("[BOOT] " + msg); return FALSE; }
+integer now(){ return llGetUnixTime(); }
+
+integer json_has(string j, list path){ if (llJsonGetValue(j, path) == JSON_INVALID) return FALSE; return TRUE; }
+
+integer send_kernel_soft_reset(){
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_KERNEL_SOFT_RST);
+    llMessageLinked(LINK_SET, K_SOFT_RESET, payload, NULL_KEY);
+    logd("kernel soft reset requested");
+    return TRUE;
+}
+
+integer request_plugin_list(){
+    llMessageLinked(LINK_SET, K_PLUGIN_LIST_REQUEST, "", NULL_KEY);
+    logd("plugin list requested");
+    return TRUE;
+}
+
+integer request_settings_sync(){
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], "settings_get");
+    llMessageLinked(LINK_SET, SETTINGS_QUERY_NUM, payload, NULL_KEY);
+    logd("settings snapshot requested");
+    return TRUE;
+}
+
+integer request_wearer_acl(){
+    key wearer = llGetOwner();
+    if (wearer == NULL_KEY) return FALSE;
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_AUTH_QUERY);
+    payload = llJsonSetValue(payload, ["avatar"], (string)wearer);
+    llMessageLinked(LINK_SET, AUTH_QUERY_NUM, payload, wearer);
+    logd("wearer ACL requested");
+    return TRUE;
+}
+
+integer finish_bootstrap(){
+    BootActive = FALSE;
+    WaitPluginList = FALSE;
+    WaitSettings = FALSE;
+    WaitAuth = FALSE;
+    BootDeadline = 0;
+    BootAttempts = 0;
+    llSetTimerEvent(0.0);
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_PLUGIN_START);
+    llMessageLinked(LINK_SET, K_PLUGIN_START, payload, NULL_KEY);
+    logd("bootstrap complete");
+    return TRUE;
+}
+
+integer bootstrap_check(){
+    if (!BootActive) return FALSE;
+    if (!WaitPluginList && !WaitSettings && !WaitAuth){
+        finish_bootstrap();
+        return TRUE;
+    }
+    return FALSE;
+}
+
+integer start_bootstrap(){
+    BootActive = TRUE;
+    BootAttempts = 0;
+    WaitPluginList = TRUE;
+    WaitSettings = TRUE;
+    WaitAuth = (llGetOwner() != NULL_KEY);
+    BootDeadline = now() + BOOT_RETRY_SEC;
+    llSetTimerEvent(TIMER_TICK_SEC);
+    send_kernel_soft_reset();
+    request_plugin_list();
+    request_settings_sync();
+    if (WaitAuth) request_wearer_acl();
+    return TRUE;
+}
+
+integer rebootstrap(){
+    if (!BootActive){
+        BootActive = TRUE;
+        BootAttempts = 0;
+    }
+    BootAttempts += 1;
+    if (BootAttempts > MaxBootAttempts){
+        BootActive = FALSE;
+        llSetTimerEvent(0.0);
+        logd("bootstrap aborted (max attempts)");
+        return FALSE;
+    }
+    WaitPluginList = TRUE;
+    WaitSettings = TRUE;
+    WaitAuth = (llGetOwner() != NULL_KEY);
+    BootDeadline = now() + BOOT_RETRY_SEC;
+    send_kernel_soft_reset();
+    request_plugin_list();
+    request_settings_sync();
+    if (WaitAuth) request_wearer_acl();
+    return TRUE;
+}
+
+integer handle_plugin_list(string payload){
+    if (!json_has(payload, ["type"])) return FALSE;
+    if (llJsonGetValue(payload, ["type"]) != MSG_PLUGIN_LIST) return FALSE;
+    WaitPluginList = FALSE;
+    bootstrap_check();
+    return TRUE;
+}
+
+integer handle_settings_sync(string payload){
+    if (!json_has(payload, ["type"])) return FALSE;
+    if (llJsonGetValue(payload, ["type"]) != MSG_SETTINGS_SYNC) return FALSE;
+    WaitSettings = FALSE;
+    bootstrap_check();
+    return TRUE;
+}
+
+integer handle_auth_result(string payload, key id){
+    if (!WaitAuth) return FALSE;
+    if (!json_has(payload, ["type"])) return FALSE;
+    if (llJsonGetValue(payload, ["type"]) != MSG_AUTH_RESULT) return FALSE;
+    key wearer = llGetOwner();
+    if (id != wearer) return FALSE;
+    WaitAuth = FALSE;
+    bootstrap_check();
+    return TRUE;
+}
+
+integer owner_changed(){
+    key cur = llGetOwner();
+    if (cur == NULL_KEY) return FALSE;
+    if (cur != LastOwner){
+        LastOwner = cur;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/* ---------- Events ---------- */
+default
+{
+    state_entry(){
+        LastOwner = llGetOwner();
+        BootActive = FALSE;
+        WaitPluginList = FALSE;
+        WaitSettings = FALSE;
+        WaitAuth = FALSE;
+        LastKernelPing = now();
+        start_bootstrap();
+    }
+
+    on_rez(integer param){
+        if (owner_changed()) llResetScript();
+    }
+
+    attach(key id){
+        if (id == NULL_KEY) return;
+        if (owner_changed()) llResetScript();
+    }
+
+    changed(integer change){
+        if (change & CHANGED_OWNER){
+            if (owner_changed()) llResetScript();
+        }
+        if (change & (CHANGED_REGION | CHANGED_TELEPORT)){
+            rebootstrap();
+        }
+    }
+
+    link_message(integer sender, integer num, string str, key id){
+        if (num == K_PLUGIN_LIST){
+            handle_plugin_list(str);
+            return;
+        }
+        if (num == SETTINGS_SYNC_NUM){
+            handle_settings_sync(str);
+            return;
+        }
+        if (num == AUTH_RESULT_NUM){
+            handle_auth_result(str, id);
+            return;
+        }
+        if (num == K_PLUGIN_PING){
+            LastKernelPing = now();
+            return;
+        }
+        if (num == K_PLUGIN_PONG){
+            LastKernelPing = now();
+            return;
+        }
+    }
+
+    timer(){
+        if (BootActive){
+            integer ts = now();
+            if (ts >= BootDeadline){
+                rebootstrap();
+                return;
+            }
+        }
+        if ((now() - LastKernelPing) > HEARTBEAT_TIMEOUT){
+            logd("heartbeat stale → reboot");
+            rebootstrap();
+        }
+    }
+}

--- a/src/future/modules/ds_collar_kmod_settings.lsl
+++ b/src/future/modules/ds_collar_kmod_settings.lsl
@@ -1,0 +1,360 @@
+/* =============================================================
+   MODULE: ds_collar_kmod_settings.lsl
+   ROLE  : Settings authority for DS Collar.
+           - Stores collar configuration in JSON (kv + lists).
+           - Responds to get/set/list mutations and broadcasts snapshots.
+           - Enforces mutual exclusivity between owner, trustees, and blacklist.
+   ============================================================= */
+
+integer DEBUG = FALSE;
+
+/* ---------- Message Types ---------- */
+string TYPE_SETTINGS_GET   = "settings_get";
+string TYPE_SETTINGS_SYNC  = "settings_sync";
+string TYPE_SET            = "set";
+string TYPE_LIST_ADD       = "list_add";
+string TYPE_LIST_REMOVE    = "list_remove";
+
+/* ---------- Link numbers ---------- */
+integer SETTINGS_QUERY_NUM = 800;
+integer SETTINGS_SYNC_NUM  = 870;
+
+/* ---------- Keys ---------- */
+string KEY_OWNER_KEY        = "owner_key";
+string KEY_OWNER_HON        = "owner_hon";
+string KEY_TRUSTEES         = "trustees";
+string KEY_TRUSTEE_HONS     = "trustee_honorifics";
+string KEY_BLACKLIST        = "blacklist";
+string KEY_PUBLIC_ACCESS    = "public_mode";
+string KEY_TPE_MODE         = "tpe_mode";
+string KEY_LOCKED           = "locked";
+string KEY_CHAT_PREFIX      = "chat_prefix";
+
+/* ---------- State ---------- */
+key     LastOwner   = NULL_KEY;
+string  KvJson      = "{}";
+integer MaxListSize = 64;
+integer LastGetTs   = 0;
+
+/* ---------- Helpers ---------- */
+integer logd(string msg){ if (DEBUG) llOwnerSay("[SETTINGS] " + msg); return FALSE; }
+integer json_has(string j, list path){ if (llJsonGetValue(j, path) == JSON_INVALID) return FALSE; return TRUE; }
+integer is_json_obj(string s){ if (llGetSubString(s, 0, 0) == "{") return TRUE; return FALSE; }
+integer is_json_arr(string s){ if (llGetSubString(s, 0, 0) == "[") return TRUE; return FALSE; }
+
+string kv_get(string key_str){
+    string v = llJsonGetValue(KvJson, [key_str]);
+    if (v == JSON_INVALID) return "";
+    return v;
+}
+
+integer kv_set_scalar(string key_str, string value){
+    string oldv = kv_get(key_str);
+    if (oldv == value) return FALSE;
+    KvJson = llJsonSetValue(KvJson, [key_str], value);
+    logd("SET " + key_str + "=" + value);
+    return TRUE;
+}
+
+integer kv_set_list(string key_str, list values){
+    string next = llList2Json(JSON_ARRAY, values);
+    string oldv = kv_get(key_str);
+    if (oldv == next) return FALSE;
+    KvJson = llJsonSetValue(KvJson, [key_str], next);
+    logd("SET " + key_str + " count=" + (string)llGetListLength(values));
+    return TRUE;
+}
+
+list json_array_to_list(string arr_json){
+    if (!is_json_arr(arr_json)) return [];
+    list out = llJson2List(arr_json);
+    integer n = llGetListLength(out);
+    if (n <= MaxListSize) return out;
+    return llList2List(out, 0, MaxListSize - 1);
+}
+
+integer list_contains(list L, string s){ if (llListFindList(L, [s]) != -1) return TRUE; return FALSE; }
+
+list list_remove_all(list L, string s){
+    integer idx = llListFindList(L, [s]);
+    while (idx != -1){
+        L = llDeleteSubList(L, idx, idx);
+        idx = llListFindList(L, [s]);
+    }
+    return L;
+}
+
+list list_unique(list L){
+    list out = [];
+    integer i = 0;
+    integer n = llGetListLength(L);
+    while (i < n){
+        string item = llList2String(L, i);
+        if (!list_contains(out, item)) out += [item];
+        i += 1;
+    }
+    return out;
+}
+
+integer is_allowed_key(string key_str){
+    if (key_str == KEY_OWNER_KEY) return TRUE;
+    if (key_str == KEY_OWNER_HON) return TRUE;
+    if (key_str == KEY_TRUSTEES) return TRUE;
+    if (key_str == KEY_TRUSTEE_HONS) return TRUE;
+    if (key_str == KEY_BLACKLIST) return TRUE;
+    if (key_str == KEY_PUBLIC_ACCESS) return TRUE;
+    if (key_str == KEY_TPE_MODE) return TRUE;
+    if (key_str == KEY_LOCKED) return TRUE;
+    if (key_str == KEY_CHAT_PREFIX) return TRUE;
+    return FALSE;
+}
+
+string normalize_mode01(string s){
+    integer v = (integer)s;
+    if (v != 0) v = 1;
+    return (string)v;
+}
+
+string sanitize_roles(string source){
+    string kv = source;
+
+    key owner = NULL_KEY;
+    string owner_str = llJsonGetValue(kv, [KEY_OWNER_KEY]);
+    if (owner_str != JSON_INVALID) owner = (key)owner_str;
+
+    list trustees = [];
+    string t_arr = llJsonGetValue(kv, [KEY_TRUSTEES]);
+    if (t_arr != JSON_INVALID && is_json_arr(t_arr)) trustees = llJson2List(t_arr);
+
+    list blacklist = [];
+    string b_arr = llJsonGetValue(kv, [KEY_BLACKLIST]);
+    if (b_arr != JSON_INVALID && is_json_arr(b_arr)) blacklist = llJson2List(b_arr);
+
+    trustees = list_unique(trustees);
+    blacklist = list_unique(blacklist);
+
+    if (owner != NULL_KEY){
+        trustees = list_remove_all(trustees, (string)owner);
+        if (list_contains(blacklist, (string)owner)) owner = NULL_KEY;
+    }
+
+    list clean_trustees = [];
+    integer i = 0;
+    integer n = llGetListLength(trustees);
+    while (i < n){
+        string who = llList2String(trustees, i);
+        if (!list_contains(blacklist, who)) clean_trustees += [who];
+        i += 1;
+    }
+    trustees = clean_trustees;
+
+    kv = llJsonSetValue(kv, [KEY_OWNER_KEY], (string)owner);
+    kv = llJsonSetValue(kv, [KEY_TRUSTEES], llList2Json(JSON_ARRAY, trustees));
+    kv = llJsonSetValue(kv, [KEY_BLACKLIST], llList2Json(JSON_ARRAY, blacklist));
+    return kv;
+}
+
+integer broadcast_sync(){
+    KvJson = sanitize_roles(KvJson);
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], TYPE_SETTINGS_SYNC);
+    payload = llJsonSetValue(payload, ["kv"], KvJson);
+    llMessageLinked(LINK_SET, SETTINGS_SYNC_NUM, payload, NULL_KEY);
+    logd("sync broadcast");
+    return TRUE;
+}
+
+integer maybe_broadcast_on_get(){
+    integer ts = llGetUnixTime();
+    if (ts == LastGetTs) return FALSE;
+    LastGetTs = ts;
+    broadcast_sync();
+    return TRUE;
+}
+
+integer apply_owner_guard(string owner_str){
+    if (owner_str == "" || owner_str == (string)NULL_KEY) return FALSE;
+    string trustees = kv_get(KEY_TRUSTEES);
+    if (is_json_arr(trustees)){
+        list t = llJson2List(trustees);
+        t = list_remove_all(t, owner_str);
+        kv_set_list(KEY_TRUSTEES, t);
+    }
+    string blacklist = kv_get(KEY_BLACKLIST);
+    if (is_json_arr(blacklist)){
+        list b = llJson2List(blacklist);
+        b = list_remove_all(b, owner_str);
+        kv_set_list(KEY_BLACKLIST, b);
+    }
+    return TRUE;
+}
+
+integer apply_trustee_add_guard(string trustee){
+    string owner = kv_get(KEY_OWNER_KEY);
+    if (owner != "" && owner != JSON_INVALID){
+        if (trustee == owner) return FALSE;
+    }
+    string blacklist = kv_get(KEY_BLACKLIST);
+    if (is_json_arr(blacklist)){
+        list b = llJson2List(blacklist);
+        b = list_remove_all(b, trustee);
+        kv_set_list(KEY_BLACKLIST, b);
+    }
+    return TRUE;
+}
+
+integer apply_blacklist_add_guard(string who){
+    string trustees = kv_get(KEY_TRUSTEES);
+    if (is_json_arr(trustees)){
+        list t = llJson2List(trustees);
+        t = list_remove_all(t, who);
+        kv_set_list(KEY_TRUSTEES, t);
+    }
+    string owner = kv_get(KEY_OWNER_KEY);
+    if (owner != "" && owner != JSON_INVALID){
+        if (who == owner){
+            kv_set_scalar(KEY_OWNER_KEY, (string)NULL_KEY);
+        }
+    }
+    return TRUE;
+}
+
+/* ---------- Events ---------- */
+default
+{
+    state_entry(){
+        LastOwner = llGetOwner();
+        broadcast_sync();
+    }
+
+    on_rez(integer param){
+        if (llGetOwner() != LastOwner) llResetScript();
+    }
+
+    attach(key id){
+        if (id == NULL_KEY) return;
+        if (llGetOwner() != LastOwner) llResetScript();
+    }
+
+    changed(integer change){
+        if (change & CHANGED_OWNER){
+            if (llGetOwner() != LastOwner) llResetScript();
+        }
+    }
+
+    link_message(integer sender, integer num, string str, key id){
+        if (num != SETTINGS_QUERY_NUM) return;
+        if (!json_has(str, ["type"])) return;
+        string t = llJsonGetValue(str, ["type"]);
+
+        if (t == TYPE_SETTINGS_GET){
+            maybe_broadcast_on_get();
+            return;
+        }
+
+        if (t == TYPE_SET){
+            if (!json_has(str, ["key"])) return;
+            string key_str = llJsonGetValue(str, ["key"]);
+            if (!is_allowed_key(key_str)) return;
+            integer changed_scalar = FALSE;
+
+            if (json_has(str, ["values"])){
+                string arr = llJsonGetValue(str, ["values"]);
+                if (is_json_arr(arr)){
+                    list values = json_array_to_list(arr);
+                    values = list_unique(values);
+                    if (key_str == KEY_TRUSTEES){
+                        string owner = kv_get(KEY_OWNER_KEY);
+                        if (owner != "" && owner != JSON_INVALID){
+                            values = list_remove_all(values, owner);
+                        }
+                        string blacklist = kv_get(KEY_BLACKLIST);
+                        if (is_json_arr(blacklist)){
+                            list b = llJson2List(blacklist);
+                            integer i = 0;
+                            while (i < llGetListLength(values)){
+                                string who = llList2String(values, i);
+                                b = list_remove_all(b, who);
+                                i += 1;
+                            }
+                            kv_set_list(KEY_BLACKLIST, b);
+                        }
+                    }
+                    if (key_str == KEY_BLACKLIST){
+                        string owner = kv_get(KEY_OWNER_KEY);
+                        if (owner != "" && owner != JSON_INVALID){
+                            if (list_contains(values, owner)) kv_set_scalar(KEY_OWNER_KEY, (string)NULL_KEY);
+                        }
+                        string trustees = kv_get(KEY_TRUSTEES);
+                        if (is_json_arr(trustees)){
+                            list tlist = llJson2List(trustees);
+                            integer i2 = 0;
+                            while (i2 < llGetListLength(values)){
+                                string who2 = llList2String(values, i2);
+                                tlist = list_remove_all(tlist, who2);
+                                i2 += 1;
+                            }
+                            kv_set_list(KEY_TRUSTEES, tlist);
+                        }
+                    }
+                    changed_scalar = kv_set_list(key_str, values);
+                }
+            }
+            else if (json_has(str, ["value"])){
+                string value = llJsonGetValue(str, ["value"]);
+                if (value != JSON_INVALID){
+                    if (key_str == KEY_PUBLIC_ACCESS) value = normalize_mode01(value);
+                    if (key_str == KEY_TPE_MODE) value = normalize_mode01(value);
+                    if (key_str == KEY_LOCKED) value = normalize_mode01(value);
+                    if (key_str == KEY_OWNER_KEY){
+                        apply_owner_guard(value);
+                    }
+                    changed_scalar = kv_set_scalar(key_str, value);
+                }
+            }
+
+            if (changed_scalar) broadcast_sync();
+            return;
+        }
+
+        if (t == TYPE_LIST_ADD || t == TYPE_LIST_REMOVE){
+            if (!json_has(str, ["key"])) return;
+            if (!json_has(str, ["elem"])) return;
+            string key_str = llJsonGetValue(str, ["key"]);
+            string elem = llJsonGetValue(str, ["elem"]);
+            if (!is_allowed_key(key_str)) return;
+            integer changed_list = FALSE;
+
+            if (t == TYPE_LIST_ADD){
+                list existing = json_array_to_list(kv_get(key_str));
+                if (list_contains(existing, elem)) return;
+                if (llGetListLength(existing) >= MaxListSize) return;
+
+                if (key_str == KEY_TRUSTEES){
+                    if (!apply_trustee_add_guard(elem)) return;
+                    existing += [elem];
+                    existing = list_unique(existing);
+                    changed_list = kv_set_list(KEY_TRUSTEES, existing);
+                }
+                else if (key_str == KEY_BLACKLIST){
+                    apply_blacklist_add_guard(elem);
+                    existing += [elem];
+                    existing = list_unique(existing);
+                    changed_list = kv_set_list(KEY_BLACKLIST, existing);
+                }
+                else {
+                    existing += [elem];
+                    existing = list_unique(existing);
+                    changed_list = kv_set_list(key_str, existing);
+                }
+            } else {
+                list existing = json_array_to_list(kv_get(key_str));
+                list next = list_remove_all(existing, elem);
+                changed_list = kv_set_list(key_str, next);
+            }
+
+            if (changed_list) broadcast_sync();
+            return;
+        }
+    }
+}

--- a/src/future/plugins/ds_collar_plugin_root_ui.lsl
+++ b/src/future/plugins/ds_collar_plugin_root_ui.lsl
@@ -1,0 +1,472 @@
+/* =============================================================
+   PLUGIN: ds_collar_plugin_root_ui.lsl
+   ROLE  : Root UI plugin for DS Collar future kernel.
+           - Registers with kernel and tracks plugin registry snapshots.
+           - Presents paginated root menu dialogs with ACL enforcement.
+           - Routes plugin selections, denies unauthorized access, and
+             reopens the menu on plugin return.
+   ============================================================= */
+
+integer DEBUG = FALSE;
+
+/* ---------- Protocol strings ---------- */
+string MSG_REGISTER        = "register";
+string MSG_REGISTER_NOW    = "register_now";
+string MSG_PLUGIN_LIST     = "plugin_list";
+string MSG_PLUGIN_START    = "plugin_start";
+string MSG_PLUGIN_RETURN   = "plugin_return";
+string MSG_PLUGIN_SOFT_RST = "plugin_soft_reset";
+string MSG_PLUGIN_PING     = "plugin_ping";
+string MSG_PLUGIN_PONG     = "plugin_pong";
+string MSG_AUTH_QUERY      = "acl_query";
+string MSG_AUTH_RESULT     = "acl_result";
+
+/* ---------- Link numbers ---------- */
+integer K_PLUGIN_REG_QUERY     = 500;
+integer K_PLUGIN_REG_REPLY     = 501;
+integer K_PLUGIN_DEREG         = 502;
+integer K_PLUGIN_SOFT_RESET    = 504;
+integer K_PLUGIN_LIST          = 600;
+integer K_PLUGIN_LIST_REQUEST  = 601;
+integer K_PLUGIN_PING          = 650;
+integer K_PLUGIN_PONG          = 651;
+integer K_PLUGIN_START         = 900;
+integer K_PLUGIN_RETURN        = 901;
+integer AUTH_QUERY_NUM         = 700;
+integer AUTH_RESULT_NUM        = 710;
+
+/* ---------- Plugin identity ---------- */
+string PLUGIN_CONTEXT = "core_root";
+string PLUGIN_LABEL   = "Root Menu";
+integer PLUGIN_SN     = 100;
+integer PLUGIN_MIN_ACL= 1;
+
+/* ---------- UI configuration ---------- */
+integer PAGE_SIZE       = 8;
+float   SESSION_TIMEOUT = 60.0;
+float   TOUCH_RANGE_M   = 5.0;
+string  BTN_PREV        = "<<";
+string  BTN_NEXT        = ">>";
+string  BTN_CLOSE       = "Close";
+string  MODAL_OK        = "OK";
+string  TITLE           = "• DS Collar •";
+
+/* ---------- Session states ---------- */
+integer SESSION_NONE = 0;
+integer SESSION_WAIT = 1;
+integer SESSION_MENU = 2;
+integer SESSION_MODAL = 3;
+
+/* ---------- Globals ---------- */
+list    Registry       = []; /* stride 3: [context,label,min_acl] */
+key     SessionUser    = NULL_KEY;
+integer SessionAcl     = -1;
+integer SessionMode    = 0;
+integer SessionPage    = 0;
+integer SessionListen  = 0;
+integer SessionChan    = 0;
+list    SessionMap     = [];
+key     LastOwner      = NULL_KEY;
+
+/* ---------- Helpers ---------- */
+integer logd(string msg){ if (DEBUG) llOwnerSay("[UI] " + msg); return TRUE; }
+
+integer json_has(string j, list path){ if (llJsonGetValue(j, path) == JSON_INVALID) return FALSE; return TRUE; }
+
+integer random_channel(){ return -200000 - (integer)llFrand(8000000.0); }
+
+integer within_range(key av){
+    if (av == NULL_KEY) return FALSE;
+    list data = llGetObjectDetails(av, [OBJECT_POS]);
+    if (llGetListLength(data) < 1) return FALSE;
+    vector pos = llList2Vector(data, 0);
+    if (pos == ZERO_VECTOR) return FALSE;
+    float dist = llVecDist(llGetPos(), pos);
+    if (dist > TOUCH_RANGE_M) return FALSE;
+    return TRUE;
+}
+
+integer registry_index(string ctx){
+    integer stride = 3;
+    integer i = 0;
+    integer n = llGetListLength(Registry);
+    while (i < n){
+        if (llList2String(Registry, i) == ctx) return i;
+        i += stride;
+    }
+    return -1;
+}
+
+integer register_self(){
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_REGISTER);
+    payload = llJsonSetValue(payload, ["context"], PLUGIN_CONTEXT);
+    payload = llJsonSetValue(payload, ["label"], PLUGIN_LABEL);
+    payload = llJsonSetValue(payload, ["min_acl"], (string)PLUGIN_MIN_ACL);
+    payload = llJsonSetValue(payload, ["sn"], (string)PLUGIN_SN);
+    payload = llJsonSetValue(payload, ["script"], llGetScriptName());
+    llMessageLinked(LINK_SET, K_PLUGIN_REG_REPLY, payload, NULL_KEY);
+    logd("register sent");
+    return TRUE;
+}
+
+integer send_plugin_pong(){
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_PLUGIN_PONG);
+    payload = llJsonSetValue(payload, ["context"], PLUGIN_CONTEXT);
+    llMessageLinked(LINK_SET, K_PLUGIN_PONG, payload, NULL_KEY);
+    return TRUE;
+}
+
+integer request_registry(){
+    llMessageLinked(LINK_SET, K_PLUGIN_LIST_REQUEST, "", NULL_KEY);
+    return TRUE;
+}
+
+integer request_acl(key av){
+    if (av == NULL_KEY) return FALSE;
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_AUTH_QUERY);
+    payload = llJsonSetValue(payload, ["avatar"], (string)av);
+    llMessageLinked(LINK_SET, AUTH_QUERY_NUM, payload, NULL_KEY);
+    logd("acl requested for " + (string)av);
+    return TRUE;
+}
+
+integer close_listener(){
+    if (SessionListen != 0){
+        llListenRemove(SessionListen);
+        SessionListen = 0;
+    }
+    SessionChan = 0;
+    return TRUE;
+}
+
+integer open_listener(key av){
+    close_listener();
+    SessionChan = random_channel();
+    SessionListen = llListen(SessionChan, "", av, "");
+    return TRUE;
+}
+
+integer close_session(){
+    close_listener();
+    SessionUser = NULL_KEY;
+    SessionAcl = -1;
+    SessionMode = SESSION_NONE;
+    SessionPage = 0;
+    SessionMap = [];
+    llSetTimerEvent(0.0);
+    return TRUE;
+}
+
+string map_command(string label){
+    integer idx = llListFindList(SessionMap, [label]);
+    if (idx == -1) return "";
+    return llList2String(SessionMap, idx + 1);
+}
+
+integer show_modal(string body, string command){
+    if (SessionUser == NULL_KEY) return FALSE;
+    SessionMap = [MODAL_OK, command];
+    SessionMode = SESSION_MODAL;
+    llDialog(SessionUser, body, [MODAL_OK], SessionChan);
+    llSetTimerEvent(SESSION_TIMEOUT);
+    return TRUE;
+}
+
+integer show_menu(){
+    if (SessionUser == NULL_KEY) return FALSE;
+    integer total = llGetListLength(Registry) / 3;
+    if (total <= 0){
+        show_modal("No installed plugins.", "modal_close");
+        return TRUE;
+    }
+    integer pages = (total + PAGE_SIZE - 1) / PAGE_SIZE;
+    if (pages <= 0) pages = 1;
+    if (SessionPage < 0) SessionPage = 0;
+    if (SessionPage >= pages) SessionPage = pages - 1;
+
+    integer start = SessionPage * PAGE_SIZE;
+    integer end = start + PAGE_SIZE;
+    if (end > total) end = total;
+
+    list buttons = [];
+    list map = [];
+    integer i = start;
+    while (i < end){
+        integer base = i * 3;
+        string ctx = llList2String(Registry, base);
+        string label = llList2String(Registry, base + 1);
+        buttons += [label];
+        map += [label, "plugin:" + ctx];
+        i += 1;
+    }
+
+    if (pages > 1){
+        if (SessionPage > 0){
+            buttons += [BTN_PREV];
+            map += [BTN_PREV, "nav:prev"];
+        }
+        if (SessionPage < (pages - 1)){
+            buttons += [BTN_NEXT];
+            map += [BTN_NEXT, "nav:next"];
+        }
+    }
+
+    buttons += [BTN_CLOSE];
+    map += [BTN_CLOSE, "menu:close"];
+
+    SessionMap = map;
+    SessionMode = SESSION_MENU;
+
+    list bodyParts = ["Select a plugin (Page ", (string)(SessionPage + 1), "/", (string)pages, ")"];
+    string body = llDumpList2String(bodyParts, "");
+    llDialog(SessionUser, body, buttons, SessionChan);
+    llSetTimerEvent(SESSION_TIMEOUT);
+    return TRUE;
+}
+
+integer start_session(key av){
+    if (av == NULL_KEY) return FALSE;
+    close_session();
+    SessionUser = av;
+    SessionAcl = -1;
+    SessionPage = 0;
+    SessionMode = SESSION_WAIT;
+    SessionMap = [];
+    open_listener(av);
+    llSetTimerEvent(SESSION_TIMEOUT);
+    request_acl(av);
+    if (llGetListLength(Registry) == 0) request_registry();
+    return TRUE;
+}
+
+integer ensure_registry(string payload){
+    if (!json_has(payload, ["type"])) return FALSE;
+    if (llJsonGetValue(payload, ["type"]) != MSG_PLUGIN_LIST) return FALSE;
+
+    list next = [];
+    integer i = 0;
+    while (llJsonValueType(payload, ["plugins", i]) != JSON_INVALID){
+        string ctx = llJsonGetValue(payload, ["plugins", i, "context"]);
+        string label = llJsonGetValue(payload, ["plugins", i, "label"]);
+        string minStr = llJsonGetValue(payload, ["plugins", i, "min_acl"]);
+        if (ctx == PLUGIN_CONTEXT){
+            i += 1;
+            continue;
+        }
+        if (ctx == "" || label == "" || minStr == JSON_INVALID){
+            i += 1;
+            continue;
+        }
+        integer min_acl = (integer)minStr;
+        next += [ctx, label, min_acl];
+        i += 1;
+    }
+
+    Registry = next;
+    logd("registry updated count=" + (string)(llGetListLength(Registry) / 3));
+
+    if (SessionMode == SESSION_MENU){
+        show_menu();
+    }
+    return TRUE;
+}
+
+integer handle_acl_result(string payload, key av){
+    if (!json_has(payload, ["type"])) return FALSE;
+    if (llJsonGetValue(payload, ["type"]) != MSG_AUTH_RESULT) return FALSE;
+    if (!json_has(payload, ["avatar"])) return FALSE;
+    if ((key)llJsonGetValue(payload, ["avatar"]) != av) return FALSE;
+
+    integer level = -1;
+    if (json_has(payload, ["level"])) level = (integer)llJsonGetValue(payload, ["level"]);
+
+    if (SessionUser != av) return TRUE;
+
+    SessionAcl = level;
+    if (SessionAcl < PLUGIN_MIN_ACL){
+        show_modal("Access denied.", "modal_close");
+        return TRUE;
+    }
+    show_menu();
+    return TRUE;
+}
+
+integer handle_plugin_start(string payload, key who){
+    if (!json_has(payload, ["type"])) return FALSE;
+    if (llJsonGetValue(payload, ["type"]) != MSG_PLUGIN_START) return FALSE;
+    string ctx = "";
+    if (json_has(payload, ["context"])) ctx = llJsonGetValue(payload, ["context"]);
+    if (ctx != "" && ctx != PLUGIN_CONTEXT) return FALSE;
+
+    key target = who;
+    if (target == NULL_KEY) target = llGetOwner();
+    if (target == NULL_KEY) return FALSE;
+    start_session(target);
+    return TRUE;
+}
+
+integer handle_plugin_return(string payload, key who){
+    if (!json_has(payload, ["type"])) return FALSE;
+    if (llJsonGetValue(payload, ["type"]) != MSG_PLUGIN_RETURN) return FALSE;
+    if (json_has(payload, ["context"])){
+        string ctx = llJsonGetValue(payload, ["context"]);
+        if (ctx != "" && ctx != PLUGIN_CONTEXT) return FALSE;
+    }
+    if (who == NULL_KEY) return FALSE;
+    start_session(who);
+    return TRUE;
+}
+
+integer handle_plugin_selection(string ctx){
+    integer idx = registry_index(ctx);
+    if (idx == -1){
+        show_modal("Plugin unavailable.", "modal_return");
+        return FALSE;
+    }
+    integer required = llList2Integer(Registry, idx + 2);
+    if (SessionAcl < required){
+        show_modal("Access denied.", "modal_return");
+        return FALSE;
+    }
+    string payload = llList2Json(JSON_OBJECT, []);
+    payload = llJsonSetValue(payload, ["type"], MSG_PLUGIN_START);
+    payload = llJsonSetValue(payload, ["context"], ctx);
+    llMessageLinked(LINK_SET, K_PLUGIN_START, payload, SessionUser);
+    close_session();
+    return TRUE;
+}
+
+/* ==================== Events ==================== */
+
+default
+{
+    state_entry(){
+        LastOwner = llGetOwner();
+        register_self();
+        request_registry();
+    }
+
+    on_rez(integer sp){
+        if (llGetOwner() != LastOwner) llResetScript();
+    }
+
+    attach(key id){
+        if (id == NULL_KEY) return;
+        if (llGetOwner() != LastOwner) llResetScript();
+    }
+
+    changed(integer change){
+        if (change & CHANGED_OWNER){
+            if (llGetOwner() != LastOwner) llResetScript();
+        }
+        if (change & CHANGED_INVENTORY){
+            request_registry();
+        }
+    }
+
+    touch_start(integer count){
+        integer i = 0;
+        while (i < count){
+            key av = llDetectedKey(i);
+            if (within_range(av)){
+                start_session(av);
+                return;
+            }
+            i += 1;
+        }
+    }
+
+    listen(integer channel, string name, key id, string message){
+        if (channel != SessionChan) return;
+        if (id != SessionUser) return;
+        string command = map_command(message);
+        if (command == "") return;
+
+        if (command == "menu:close"){
+            close_session();
+            return;
+        }
+        if (command == "nav:prev"){
+            SessionPage -= 1;
+            show_menu();
+            return;
+        }
+        if (command == "nav:next"){
+            SessionPage += 1;
+            show_menu();
+            return;
+        }
+        if (command == "modal_return"){
+            show_menu();
+            return;
+        }
+        if (command == "modal_close"){
+            close_session();
+            return;
+        }
+        if (llSubStringIndex(command, "plugin:") == 0){
+            string ctx = llGetSubString(command, 7, -1);
+            handle_plugin_selection(ctx);
+            return;
+        }
+    }
+
+    link_message(integer sender, integer num, string str, key id){
+        if (num == K_PLUGIN_PING){
+            if (json_has(str, ["type"]) && llJsonGetValue(str, ["type"]) == MSG_PLUGIN_PING){
+                string ctx = "";
+                if (json_has(str, ["context"])) ctx = llJsonGetValue(str, ["context"]);
+                if (ctx == "" || ctx == PLUGIN_CONTEXT){
+                    send_plugin_pong();
+                }
+            }
+            return;
+        }
+        if (num == K_PLUGIN_REG_QUERY){
+            if (json_has(str, ["type"]) && llJsonGetValue(str, ["type"]) == MSG_REGISTER_NOW){
+                if (json_has(str, ["script"])){
+                    string want = llJsonGetValue(str, ["script"]);
+                    if (want != "" && want != llGetScriptName()) return;
+                }
+                register_self();
+            }
+            return;
+        }
+        if (num == K_PLUGIN_SOFT_RESET){
+            if (json_has(str, ["type"]) && llJsonGetValue(str, ["type"]) == MSG_PLUGIN_SOFT_RST){
+                if (json_has(str, ["context"])){
+                    string ctx = llJsonGetValue(str, ["context"]);
+                    if (ctx != "" && ctx != PLUGIN_CONTEXT) return;
+                }
+                register_self();
+                request_registry();
+            }
+            return;
+        }
+        if (num == K_PLUGIN_LIST){
+            ensure_registry(str);
+            return;
+        }
+        if (num == AUTH_RESULT_NUM){
+            handle_acl_result(str, id);
+            return;
+        }
+        if (num == K_PLUGIN_START){
+            if (handle_plugin_start(str, id)) return;
+            return;
+        }
+        if (num == K_PLUGIN_RETURN){
+            if (handle_plugin_return(str, id)) return;
+            return;
+        }
+    }
+
+    timer(){
+        if (SessionMode != SESSION_NONE){
+            close_session();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a future root UI plugin that registers with the kernel and tracks plugin registry updates
- implement paginated dialogs that list installed plugins, handle navigation, and show a modal when no plugins are available
- enforce ACL checks for each selection, issuing denied dialogs and reopening the menu or forwarding authorized requests to the target plugin

## Testing
- not run (LSL code)


------
https://chatgpt.com/codex/tasks/task_e_68d51896548c832ba24121ba3f36ee54