### PR TITLE
Add script identifier to owner plugin registration

### DIFF
--- a/src/stable/plugins/ds_collar_plugin_owner.lsl
+++ b/src/stable/plugins/ds_collar_plugin_owner.lsl
@@ -152,6 +152,7 @@ integer register_plugin() {
     j = llJsonSetValue(j, ["label"],    PLUGIN_LABEL);
     j = llJsonSetValue(j, ["min_acl"],  "0");                // matches your current file
     j = llJsonSetValue(j, ["context"],  PLUGIN_CONTEXT);
+    j = llJsonSetValue(j, ["script"],   llGetScriptName());
     llMessageLinked(LINK_SET, K_PLUGIN_REG_REPLY, j, NULL_KEY);
     logd("Registered.");
     return 0;


### PR DESCRIPTION
## Summary
- ensure the owner plugin includes its script name when registering with the kernel

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5b6f775c8832bb39ca19a44c42c05