### PR TITLE
Ensure owner plugin is visible to unowned wearers

### DIFF
--- a/src/stable/modules/ds_collar_kmod_ui.lsl
+++ b/src/stable/modules/ds_collar_kmod_ui.lsl
@@ -35,6 +35,9 @@ string BTN_NAV_LEFT  = "<<";
 string BTN_NAV_GAP   = " ";
 string BTN_NAV_RIGHT = ">>";
 
+/* ACL tiers (mirrors AUTH module) */
+integer ACL_UNOWNED = 4;
+
 /* ---------- State ---------- */
 /* Flattened registry: [label,context,min_acl,has_tpe,label_tpe,tpe_min_acl,audience,...] */
 list    All = [];
@@ -151,10 +154,11 @@ list filterForViewer(){
 
         if (isCoreOwner){
             if (IsWearer){
-                if (OwnerSet){
-                    include = TRUE;
-                } else {
-                    include = FALSE;
+                if (!OwnerSet){
+                    /* Unowned wearers need the Owner plugin to set a new owner. */
+                    if (Acl < ACL_UNOWNED){
+                        include = FALSE;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- allow the root UI to keep the Owner plugin visible for unowned wearers so they can set an owner
- mirror the ACL_UNOWNED constant inside the UI module for the new visibility check

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5bf688604832b827cc184e3d85e6c