### PR TITLE
Prevent owner menu reopening after add-owner confirmation

### DIFF
--- a/src/stable/plugins/ds_collar_plugin_owner.lsl
+++ b/src/stable/plugins/ds_collar_plugin_owner.lsl
@@ -634,8 +634,17 @@ default{
                 push_settings();
                 dialog_to(newOwner, wearer_display_name() + " has submitted to you as their \"" + hon + "\".", ["OK"]);
                 dialog_to(llGetOwner(), "You have submitted to " + candidate_display_name(newOwner) + " as your " + hon + ".", ["OK"]);
-                UiContext = "menu";
-                show_menu(User);
+                //PATCH: prevent the owner plugin menu from reopening after wearer confirmation.
+                UiContext = "";
+                UiParam1 = "";
+                UiParam2 = "";
+                UiData = "";
+                key priorUser = User;
+                User = NULL_KEY;
+                reset_listen();
+                if (priorUser != NULL_KEY){
+                    ui_return_root(priorUser);
+                }
                 return;
             }
             show_menu(User);


### PR DESCRIPTION
## Summary
- prevent the owner plugin menu from reopening after the wearer confirms a new owner
- clear session state, return to the root UI, and drop the final OK listener to avoid implicit menu relaunches

## Testing
- not run (Second Life environment required)


------
https://chatgpt.com/codex/tasks/task_e_68d798c4f7a4832b8ce8e0d9d5027096