### PR TITLE
Handle empty blacklist remove menu

### DIFF
--- a/src/stable/plugins/ds_collar_plugin_blacklist.lsl
+++ b/src/stable/plugins/ds_collar_plugin_blacklist.lsl
@@ -235,7 +235,9 @@ integer show_main_menu(key user) {
 
 integer show_remove_menu(key user) {
     if (llGetListLength(Blacklist) == 0) {
-        show_main_menu(user);
+        //PATCH: Present info dialog when blacklist is empty to avoid blank remove menu.
+        begin_dialog(user, "info", "Blacklist is empty.", [BTN_BACK]);
+        logd("Remove menu empty.");
         return 0;
     }
 


### PR DESCRIPTION
## Summary
- show an informational dialog when the blacklist is empty instead of reopening the main menu
- avoid invoking llDialog with an empty remove list, preventing the viewer error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97215394c832bb6010927c832f4a6