### PR TITLE
Allow ACL level 2 to access blacklist plugin

### DIFF
--- a/src/stable/plugins/ds_collar_plugin_blacklist.lsl
+++ b/src/stable/plugins/ds_collar_plugin_blacklist.lsl
@@ -38,7 +38,7 @@ string TYPE_SETTINGS_SET        = "set";
 /* ---------- Identity ---------- */
 integer PLUGIN_SN        = 0;
 string  PLUGIN_LABEL     = "Blacklist";
-integer PLUGIN_MIN_ACL   = 3;
+integer PLUGIN_MIN_ACL   = 2; // ACL_OWNED - allow safety access for level 2 users
 string  PLUGIN_CONTEXT   = "core_blacklist";
 string  ROOT_CONTEXT     = "core_root";
 


### PR DESCRIPTION
## Summary
- lower the blacklist plugin registration threshold to ACL level 2 so safety controls remain available to those users

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9764eec10832b8f70b8f554ecf919