### PR TITLE
Fix display_name event syntax guards

### DIFF
--- a/src/stable/plugins/ds_collar_plugin_owner.lsl
+++ b/src/stable/plugins/ds_collar_plugin_owner.lsl
@@ -587,17 +587,22 @@ default{
         }
     }
 
+    /* Handle responses from llRequestDisplayName. */
     display_name(key agent, string name){
-        if (agent != CollarOwner) return;
-        if (CollarOwnerDisplayQuery == NULL_KEY) return;
+        if (agent != CollarOwner) {
+            return;
+        }
+        if (CollarOwnerDisplayQuery == NULL_KEY) {
+            return;
+        }
 
         CollarOwnerDisplayQuery = NULL_KEY;
 
-        if (name != "" && name != "???"){
+        if (name != "" && name != "???") {
             CollarOwnerDisplay = name;
         }
 
-        if (User != NULL_KEY && Listen != 0 && UiContext == "menu"){
+        if (User != NULL_KEY && Listen != 0 && UiContext == "menu") {
             show_menu(User);
         }
     }


### PR DESCRIPTION
## Summary
- wrap the owner plugin's display_name event guards in braces for clarity and to avoid syntax errors
- add a brief comment explaining the purpose of the display_name handler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da1b74e1b8832b8e6a88f46b5e5b76